### PR TITLE
이메일 중복확인 관련 로직 추가

### DIFF
--- a/src/main/java/team_questio/questio/common/exception/code/AuthError.java
+++ b/src/main/java/team_questio/questio/common/exception/code/AuthError.java
@@ -10,7 +10,8 @@ public enum AuthError implements ErrorCode {
     CERTIFICATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "A005", "인증번호를 확인하는 중 오류가 발생했습니다."),
     CERTIFICATION_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "A006", "인증 정보를 찾을 수 없습니다."),
     AUTHORIZATION_FAILED(HttpStatus.UNAUTHORIZED, "A007", "유효하지 않은 토큰입니다"),
-    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "A008", "유효하지 않은 리프레시 토큰입니다");
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "A008", "유효하지 않은 리프레시 토큰입니다"),
+    EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "A009", "이미 가입된 이메일입니다");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/team_questio/questio/security/application/AuthenticationService.java
+++ b/src/main/java/team_questio/questio/security/application/AuthenticationService.java
@@ -32,7 +32,7 @@ public class AuthenticationService {
 
     @Transactional
     public void sendEmail(String email) {
-        if (userRepository.existsByUsernameAndUserAccountType(email, AccountType.NORMAL)) {
+        if (existsUsername(email)) {
             throw QuestioException.of(AuthError.EMAIL_ALREADY_EXISTS);
         }
 
@@ -51,6 +51,10 @@ public class AuthenticationService {
         }
 
         saveSecretCode(email, code);
+    }
+
+    private boolean existsUsername(String email) {
+        return userRepository.existsByUsernameAndUserAccountType(email, AccountType.NORMAL);
     }
 
     @Transactional

--- a/src/main/java/team_questio/questio/security/application/AuthenticationService.java
+++ b/src/main/java/team_questio/questio/security/application/AuthenticationService.java
@@ -15,6 +15,8 @@ import team_questio.questio.common.exception.QuestioException;
 import team_questio.questio.common.exception.code.AuthError;
 import team_questio.questio.infra.RedisUtil;
 import team_questio.questio.security.util.CertificationUtil;
+import team_questio.questio.user.domain.AccountType;
+import team_questio.questio.user.persistence.UserRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -26,8 +28,14 @@ public class AuthenticationService {
     private final JavaMailSender mailSender;
     private final SpringTemplateEngine templateEngine;
 
+    private final UserRepository userRepository;
+
     @Transactional
     public void sendEmail(String email) {
+        if (userRepository.existsByUsernameAndUserAccountType(email, AccountType.NORMAL)) {
+            throw QuestioException.of(AuthError.EMAIL_ALREADY_EXISTS);
+        }
+
         var code = CertificationUtil.generateCertificationNumber();
         var htmlContent = createHtmlContent(code);
         MimeMessage message = mailSender.createMimeMessage();

--- a/src/main/java/team_questio/questio/user/application/UserService.java
+++ b/src/main/java/team_questio/questio/user/application/UserService.java
@@ -8,6 +8,7 @@ import team_questio.questio.common.exception.QuestioException;
 import team_questio.questio.common.exception.code.AuthError;
 import team_questio.questio.infra.RedisUtil;
 import team_questio.questio.user.application.command.SignUpCommand;
+import team_questio.questio.user.domain.AccountType;
 import team_questio.questio.user.domain.User;
 import team_questio.questio.user.persistence.UserRepository;
 
@@ -20,8 +21,11 @@ public class UserService {
     private final RedisUtil redisUtil;
 
     public void registerUser(SignUpCommand command) {
-        verifyEmailCertified(command.username());
+        if (userRepository.existsByUsernameAndUserAccountType(command.username(), AccountType.NORMAL)) {
+            throw QuestioException.of(AuthError.EMAIL_ALREADY_EXISTS);
+        }
 
+        verifyEmailCertified(command.username());
         var encodedPassword = passwordEncoder.encode(command.password());
         var user = User.of(command.username(), encodedPassword);
         userRepository.save(user);

--- a/src/main/java/team_questio/questio/user/application/UserService.java
+++ b/src/main/java/team_questio/questio/user/application/UserService.java
@@ -21,7 +21,7 @@ public class UserService {
     private final RedisUtil redisUtil;
 
     public void registerUser(SignUpCommand command) {
-        if (userRepository.existsByUsernameAndUserAccountType(command.username(), AccountType.NORMAL)) {
+        if (existUsername(command.username())) {
             throw QuestioException.of(AuthError.EMAIL_ALREADY_EXISTS);
         }
 
@@ -29,6 +29,10 @@ public class UserService {
         var encodedPassword = passwordEncoder.encode(command.password());
         var user = User.of(command.username(), encodedPassword);
         userRepository.save(user);
+    }
+
+    private boolean existUsername(final String username) {
+        return userRepository.existsByUsernameAndUserAccountType(username, AccountType.NORMAL);
     }
 
     private void verifyEmailCertified(String username) {

--- a/src/test/java/team_questio/questio/user/application/UserServiceTest.java
+++ b/src/test/java/team_questio/questio/user/application/UserServiceTest.java
@@ -1,0 +1,63 @@
+package team_questio.questio.user.application;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import team_questio.questio.common.exception.QuestioException;
+import team_questio.questio.common.exception.code.AuthError;
+import team_questio.questio.infra.RedisUtil;
+import team_questio.questio.user.application.command.SignUpCommand;
+import team_questio.questio.user.persistence.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @Mock
+    private RedisUtil redisUtil;
+
+    @InjectMocks
+    private UserService userService;
+
+    @DisplayName("[유저 테스트] 중복된 이메일 테스트")
+    @Test
+    void duplicatedEmailTest() {
+        //given
+        final String email = "test@test.com";
+        final String password = "test";
+        SignUpCommand command = new SignUpCommand(email, password);
+        given(userRepository.existsByUsernameAndUserAccountType(any(), any())).willReturn(true);
+
+        //when, then
+        assertThatThrownBy(() -> userService.registerUser(command))
+                .isInstanceOf(QuestioException.class)
+                .hasMessage(AuthError.EMAIL_ALREADY_EXISTS.message());
+    }
+
+
+    @DisplayName("[유저 테스트] 가입 성공 테스트")
+    @Test
+    void successRegisterTest() {
+        //given
+        final String email = "test";
+        final String password = "test";
+        SignUpCommand command = new SignUpCommand(email, password);
+        given(userRepository.existsByUsernameAndUserAccountType(any(), any())).willReturn(false);
+        given(redisUtil.getEmailCertificationSuccessKey(any())).willReturn("test");
+        given(redisUtil.getData(any(), any())).willReturn(java.util.Optional.of("test"));
+
+        //when
+        assertThatNoException().isThrownBy(() -> userService.registerUser(command));
+    }
+}


### PR DESCRIPTION
### ✨ 작업 내용

- 이메일 중복 관련 확인 로직을 추가하였습니다.
- 이메일 검증 시, 가입 시 두번 확인합니다.

---

### ✨ 참고 사항

- 없습니다.

---

### ⏰ 현재 버그

- 없습니다.

---

### ✏ Git Close

closes #31 