### PR TITLE
잔여 횟수 조회 시 횟수 차감하는 오류 수정

### DIFF
--- a/src/main/java/team_questio/questio/common/exception/code/PortfolioError.java
+++ b/src/main/java/team_questio/questio/common/exception/code/PortfolioError.java
@@ -7,7 +7,7 @@ public enum PortfolioError implements ErrorCode {
     PORTFOLIO_NOT_OWN(HttpStatus.UNAUTHORIZED, "P002", "포트폴리오에 접근할 수 없습니다."),
     QUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "P003", "일치하는 질문을 찾을 수 없습니다."),
     FEEDBACK_INVALID(HttpStatus.BAD_REQUEST, "P004", "적절하지 않은 피드백입니다."),
-    EXCEEDED_ATTEMPTS(HttpStatus.FORBIDDEN, "P005", "포트폴리오 업로드 한도를 초과하였습니다.");
+    EXCEEDED_ATTEMPT(HttpStatus.FORBIDDEN, "P005", "포트폴리오 업로드 한도를 초과하였습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/team_questio/questio/portfolio/application/PortfolioFacadeService.java
+++ b/src/main/java/team_questio/questio/portfolio/application/PortfolioFacadeService.java
@@ -21,7 +21,7 @@ public class PortfolioFacadeService {
 
     @Transactional
     public GenerationInfo createPortfolio(PortfolioCommand portfolioCommand) {
-        var remaining = userService.countRemaining(portfolioCommand.userId());
+        var remaining = userService.deductRemaining(portfolioCommand.userId());
 
         var portfolioId = portfolioService.createPortfolio(portfolioCommand);
         var questions = gptService.generateQuestion(GptParam.of(portfolioCommand.content()));

--- a/src/main/java/team_questio/questio/portfolio/application/PortfolioFacadeService.java
+++ b/src/main/java/team_questio/questio/portfolio/application/PortfolioFacadeService.java
@@ -21,7 +21,7 @@ public class PortfolioFacadeService {
 
     @Transactional
     public GenerationInfo createPortfolio(PortfolioCommand portfolioCommand) {
-        var remaining = userService.deductRemaining(portfolioCommand.userId());
+        var remaining = userService.deductQuota(portfolioCommand.userId());
 
         var portfolioId = portfolioService.createPortfolio(portfolioCommand);
         var questions = gptService.generateQuestion(GptParam.of(portfolioCommand.content()));

--- a/src/main/java/team_questio/questio/security/application/PrincipleDetailService.java
+++ b/src/main/java/team_questio/questio/security/application/PrincipleDetailService.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
@@ -23,6 +24,9 @@ import team_questio.questio.user.persistence.UserRepository;
 @RequiredArgsConstructor
 public class PrincipleDetailService extends DefaultOAuth2UserService implements UserDetailsService {
     private final UserRepository userRepository;
+
+    @Value("${user.quota}")
+    private Integer quota;
 
     /*
      * This method is used to normal user login.
@@ -88,8 +92,7 @@ public class PrincipleDetailService extends DefaultOAuth2UserService implements 
 
     private void registerOAuthUser(String username, AccountType registration) {
         var password = RandomStringUtils.random(20);
-        var user = User.of(username, password, registration);
+        var user = User.of(username, password, registration, quota);
         userRepository.save(user);
     }
-
 }

--- a/src/main/java/team_questio/questio/security/application/PrincipleDetailService.java
+++ b/src/main/java/team_questio/questio/security/application/PrincipleDetailService.java
@@ -4,7 +4,6 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
@@ -24,9 +23,6 @@ import team_questio.questio.user.persistence.UserRepository;
 @RequiredArgsConstructor
 public class PrincipleDetailService extends DefaultOAuth2UserService implements UserDetailsService {
     private final UserRepository userRepository;
-
-    @Value("${user.quota}")
-    private Integer quota;
 
     /*
      * This method is used to normal user login.
@@ -92,7 +88,7 @@ public class PrincipleDetailService extends DefaultOAuth2UserService implements 
 
     private void registerOAuthUser(String username, AccountType registration) {
         var password = RandomStringUtils.random(20);
-        var user = User.of(username, password, registration, quota);
+        var user = User.of(username, password, registration);
         userRepository.save(user);
     }
 }

--- a/src/main/java/team_questio/questio/user/application/UserService.java
+++ b/src/main/java/team_questio/questio/user/application/UserService.java
@@ -2,7 +2,6 @@ package team_questio.questio.user.application;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import team_questio.questio.common.exception.QuestioException;
@@ -21,9 +20,6 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final RedisUtil redisUtil;
 
-    @Value("${user.quota}")
-    private Integer quota;
-
     public void registerUser(SignUpCommand command) {
         if (existUsername(command.username())) {
             throw QuestioException.of(AuthError.EMAIL_ALREADY_EXISTS);
@@ -31,7 +27,7 @@ public class UserService {
 
         verifyEmailCertified(command.username());
         var encodedPassword = passwordEncoder.encode(command.password());
-        var user = User.of(command.username(), encodedPassword, quota);
+        var user = User.of(command.username(), encodedPassword);
         userRepository.save(user);
     }
 

--- a/src/main/java/team_questio/questio/user/application/UserService.java
+++ b/src/main/java/team_questio/questio/user/application/UserService.java
@@ -21,7 +21,7 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final RedisUtil redisUtil;
 
-    @Value("${portfolio.quota}")
+    @Value("${user.quota}")
     private Integer quota;
 
     public void registerUser(SignUpCommand command) {
@@ -31,22 +31,22 @@ public class UserService {
 
         verifyEmailCertified(command.username());
         var encodedPassword = passwordEncoder.encode(command.password());
-        var user = User.of(command.username(), encodedPassword);
+        var user = User.of(command.username(), encodedPassword, quota);
         userRepository.save(user);
     }
 
-    public Integer deductRemaining(Long id) {
+    public Integer deductQuota(Long id) {
         var user = userRepository.findById(id)
             .orElseThrow(() -> QuestioException.of(AuthError.USER_NOT_FOUND));
 
-        user.deductRemaining(quota);
-        return user.countRemaining(quota);
+        user.deductQuota();
+        return user.getQuota();
     }
 
-    public Integer countRemaining(Long id) {
+    public Integer getQuota(Long id) {
         var user = userRepository.findById(id)
             .orElseThrow(() -> QuestioException.of(AuthError.USER_NOT_FOUND));
-        return user.countRemaining(quota);
+        return user.getQuota();
     }
 
     private boolean existUsername(final String username) {
@@ -59,5 +59,4 @@ public class UserService {
                 .orElseThrow(() -> QuestioException.of(AuthError.CERTIFICATION_INFO_NOT_FOUND));
         redisUtil.deleteData(key);
     }
-
 }

--- a/src/main/java/team_questio/questio/user/application/UserService.java
+++ b/src/main/java/team_questio/questio/user/application/UserService.java
@@ -35,6 +35,14 @@ public class UserService {
         userRepository.save(user);
     }
 
+    public Integer deductRemaining(Long id) {
+        var user = userRepository.findById(id)
+            .orElseThrow(() -> QuestioException.of(AuthError.USER_NOT_FOUND));
+
+        user.deductRemaining(quota);
+        return user.countRemaining(quota);
+    }
+
     public Integer countRemaining(Long id) {
         var user = userRepository.findById(id)
             .orElseThrow(() -> QuestioException.of(AuthError.USER_NOT_FOUND));

--- a/src/main/java/team_questio/questio/user/domain/User.java
+++ b/src/main/java/team_questio/questio/user/domain/User.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Enumerated;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 import team_questio.questio.common.exception.QuestioException;
 import team_questio.questio.common.exception.code.PortfolioError;
 import team_questio.questio.common.persistence.BaseEntity;
@@ -23,27 +24,26 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private AccountType userAccountType = AccountType.NORMAL;
 
-    private Integer quota;
+    @ColumnDefault("0")
+    private Integer quota = 5;
 
-    private User(String username, String password, Integer quota) {
+    private User(String username, String password) {
         this.username = username;
         this.password = password;
-        this.quota = quota;
     }
 
-    private User(String username, String password, AccountType userAccountType, Integer quota) {
+    private User(String username, String password, AccountType userAccountType) {
         this.username = username;
         this.password = password;
         this.userAccountType = userAccountType;
-        this.quota = quota;
     }
 
-    public static User of(String username, String password, Integer quota) {
-        return new User(username, password, quota);
+    public static User of(String username, String password) {
+        return new User(username, password);
     }
 
-    public static User of(String username, String password, AccountType userAccountType, Integer quota) {
-        return new User(username, password, userAccountType, quota);
+    public static User of(String username, String password, AccountType userAccountType) {
+        return new User(username, password, userAccountType);
     }
 
     public void deductQuota() {

--- a/src/main/java/team_questio/questio/user/domain/User.java
+++ b/src/main/java/team_questio/questio/user/domain/User.java
@@ -48,12 +48,14 @@ public class User extends BaseEntity {
         return new User(username, password, userAccountType);
     }
 
-    public Integer countRemaining(Integer quota) {
+    public void deductRemaining(Integer quota) {
         if (this.usageCount.equals(quota)) {
             throw QuestioException.of(PortfolioError.EXCEEDED_ATTEMPTS);
         }
         this.usageCount++;
+    }
 
+    public Integer countRemaining(Integer quota) {
         return quota - usageCount;
     }
 }

--- a/src/main/java/team_questio/questio/user/domain/User.java
+++ b/src/main/java/team_questio/questio/user/domain/User.java
@@ -6,7 +6,6 @@ import jakarta.persistence.Enumerated;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
 import team_questio.questio.common.exception.QuestioException;
 import team_questio.questio.common.exception.code.PortfolioError;
 import team_questio.questio.common.persistence.BaseEntity;
@@ -24,7 +23,6 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private AccountType userAccountType = AccountType.NORMAL;
 
-    @ColumnDefault("0")
     private Integer quota = 5;
 
     private User(String username, String password) {

--- a/src/main/java/team_questio/questio/user/domain/User.java
+++ b/src/main/java/team_questio/questio/user/domain/User.java
@@ -6,15 +6,12 @@ import jakarta.persistence.Enumerated;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.annotations.DynamicInsert;
 import team_questio.questio.common.exception.QuestioException;
 import team_questio.questio.common.exception.code.PortfolioError;
 import team_questio.questio.common.persistence.BaseEntity;
 
 @Entity
 @Getter
-@DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
     private String username;
@@ -26,36 +23,33 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private AccountType userAccountType = AccountType.NORMAL;
 
-    @ColumnDefault("0")
-    private Integer usageCount;
+    private Integer quota;
 
-    private User(String username, String password) {
+    private User(String username, String password, Integer quota) {
         this.username = username;
         this.password = password;
+        this.quota = quota;
     }
 
-    private User(String username, String password, AccountType userAccountType) {
+    private User(String username, String password, AccountType userAccountType, Integer quota) {
         this.username = username;
         this.password = password;
         this.userAccountType = userAccountType;
+        this.quota = quota;
     }
 
-    public static User of(String username, String password) {
-        return new User(username, password);
+    public static User of(String username, String password, Integer quota) {
+        return new User(username, password, quota);
     }
 
-    public static User of(String username, String password, AccountType userAccountType) {
-        return new User(username, password, userAccountType);
+    public static User of(String username, String password, AccountType userAccountType, Integer quota) {
+        return new User(username, password, userAccountType, quota);
     }
 
-    public void deductRemaining(Integer quota) {
-        if (this.usageCount.equals(quota)) {
-            throw QuestioException.of(PortfolioError.EXCEEDED_ATTEMPTS);
+    public void deductQuota() {
+        if (this.quota.equals(0)) {
+            throw QuestioException.of(PortfolioError.EXCEEDED_ATTEMPT);
         }
-        this.usageCount++;
-    }
-
-    public Integer countRemaining(Integer quota) {
-        return quota - usageCount;
+        this.quota--;
     }
 }

--- a/src/main/java/team_questio/questio/user/persentation/UserController.java
+++ b/src/main/java/team_questio/questio/user/persentation/UserController.java
@@ -30,10 +30,12 @@ public class UserController implements UserApiController {
 
     @GetMapping("/remaining")
     public ResponseEntity<RemainingResponse> getRemaining(Authentication authentication) {
-        Long id = Long.valueOf(authentication.getPrincipal().toString());
+        var id = Long.valueOf(authentication.getPrincipal().toString());
+        var quota = userService.getQuota(id);
 
+        var response = RemainingResponse.of(quota);
         return ResponseEntity.ok()
-            .body(RemainingResponse.of(userService.getQuota(id)));
+            .body(response);
     }
 
     @GetMapping("/username")

--- a/src/main/java/team_questio/questio/user/persentation/UserController.java
+++ b/src/main/java/team_questio/questio/user/persentation/UserController.java
@@ -32,6 +32,6 @@ public class UserController implements UserApiController {
         Long id = Long.valueOf(authentication.getPrincipal().toString());
 
         return ResponseEntity.ok()
-            .body(RemainingResponse.of(userService.countRemaining(id)));
+            .body(RemainingResponse.of(userService.getQuota(id)));
     }
 }


### PR DESCRIPTION
### ✨ 작업 내용

- 잔여 횟수 조회 시 발생하는 오류를 수정합니다.
- `User` entity에서 사용 횟수가 아닌 잔여 횟수로 관리하도록 변경하였습니다.

---

### ✨ 참고 사항

- 업로드 횟수 초기화 시 프로퍼티 값을 이용하지 않습니다.
- 우선 5회로 초기화되도록 해두었습니다.

---

### ⏰ 현재 버그

---

### ✏ Git Close

close #59
close #64