### PR TITLE
회원가입 시, username을 확인하는 로직을 수정했어요

### DIFF
--- a/src/main/java/team_questio/questio/common/exception/code/AuthError.java
+++ b/src/main/java/team_questio/questio/common/exception/code/AuthError.java
@@ -11,7 +11,10 @@ public enum AuthError implements ErrorCode {
     CERTIFICATION_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "A006", "인증 정보를 찾을 수 없습니다."),
     AUTHORIZATION_FAILED(HttpStatus.UNAUTHORIZED, "A007", "유효하지 않은 토큰입니다"),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "A008", "유효하지 않은 리프레시 토큰입니다"),
-    EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "A009", "이미 가입된 이메일입니다");
+    EMAIL_ALREADY_EXISTS_NORMAL(HttpStatus.BAD_REQUEST, "A009", "이미 일반 계정으로 가입된 이메일입니다"),
+    EMAIL_ALREADY_EXISTS_KAKAO(HttpStatus.BAD_REQUEST, "A010", "이미 카카오 계정으로 가입된 이메일입니다"),
+    EMAIL_ALREADY_EXIST_NAVER(HttpStatus.BAD_REQUEST, "A011", "이미 네이버 계정으로 가입된 이메일입니다"),
+    EMAIL_ALREADY_EXIST_GOOGLE(HttpStatus.BAD_REQUEST, "A012", "이미 구글 계정으로 가입된 이메일입니다");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/team_questio/questio/security/config/SecurityServiceConfig.java
+++ b/src/main/java/team_questio/questio/security/config/SecurityServiceConfig.java
@@ -1,0 +1,24 @@
+package team_questio.questio.security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import team_questio.questio.security.application.PrincipleDetailService;
+import team_questio.questio.user.persistence.UserRepository;
+
+@Configuration
+public class SecurityServiceConfig {
+
+    @Bean
+    public DefaultOAuth2UserService defaultOAuth2UserService() {
+        return new DefaultOAuth2UserService();
+    }
+
+    @Bean
+    public PrincipleDetailService principleDetailService(
+            DefaultOAuth2UserService defaultOAuth2UserService,
+            UserRepository userRepository
+    ) {
+        return new PrincipleDetailService(userRepository, defaultOAuth2UserService);
+    }
+}

--- a/src/main/java/team_questio/questio/user/application/UserService.java
+++ b/src/main/java/team_questio/questio/user/application/UserService.java
@@ -9,7 +9,6 @@ import team_questio.questio.common.exception.QuestioException;
 import team_questio.questio.common.exception.code.AuthError;
 import team_questio.questio.infra.RedisUtil;
 import team_questio.questio.user.application.command.SignUpCommand;
-import team_questio.questio.user.domain.AccountType;
 import team_questio.questio.user.domain.User;
 import team_questio.questio.user.persistence.UserRepository;
 
@@ -25,9 +24,7 @@ public class UserService {
     private Integer quota;
 
     public void registerUser(SignUpCommand command) {
-        if (existUsername(command.username())) {
-            throw QuestioException.of(AuthError.EMAIL_ALREADY_EXISTS);
-        }
+        checkUsernameDuplicated(command.username());
 
         verifyEmailCertified(command.username());
         var encodedPassword = passwordEncoder.encode(command.password());
@@ -41,8 +38,22 @@ public class UserService {
         return user.countRemaining(quota);
     }
 
-    private boolean existUsername(final String username) {
-        return userRepository.existsByUsernameAndUserAccountType(username, AccountType.NORMAL);
+    private void checkUsernameDuplicated(final String username) {
+        userRepository.findByUsername(username)
+                .ifPresent(user -> {
+                    if (user.isNormalUser()) {
+                        throw QuestioException.of(AuthError.EMAIL_ALREADY_EXISTS_NORMAL);
+                    }
+                    if (user.isKakaoUser()) {
+                        throw QuestioException.of(AuthError.EMAIL_ALREADY_EXISTS_KAKAO);
+                    }
+                    if (user.isNaverUser()) {
+                        throw QuestioException.of(AuthError.EMAIL_ALREADY_EXIST_NAVER);
+                    }
+                    if (user.isGoogleUser()) {
+                        throw QuestioException.of(AuthError.EMAIL_ALREADY_EXIST_GOOGLE);
+                    }
+                });
     }
 
     private void verifyEmailCertified(String username) {

--- a/src/main/java/team_questio/questio/user/domain/User.java
+++ b/src/main/java/team_questio/questio/user/domain/User.java
@@ -56,4 +56,21 @@ public class User extends BaseEntity {
 
         return quota - usageCount;
     }
+
+    public boolean isKakaoUser() {
+        return AccountType.KAKAO.equals(this.userAccountType);
+    }
+
+    public boolean isGoogleUser() {
+        return AccountType.GOOGLE.equals(this.userAccountType);
+    }
+
+    public boolean isNaverUser() {
+        return AccountType.NAVER.equals(this.userAccountType);
+    }
+
+    public boolean isNormalUser() {
+        return AccountType.NORMAL.equals(this.userAccountType);
+    }
+
 }

--- a/src/main/java/team_questio/questio/user/persistence/UserRepository.java
+++ b/src/main/java/team_questio/questio/user/persistence/UserRepository.java
@@ -11,4 +11,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
 
     Optional<User> findByUsernameAndUserAccountType(String username, AccountType userAccountType);
+
+    boolean existsByUsernameAndUserAccountType(String username, AccountType userAccountType);
 }

--- a/src/main/java/team_questio/questio/user/persistence/UserRepository.java
+++ b/src/main/java/team_questio/questio/user/persistence/UserRepository.java
@@ -8,7 +8,7 @@ import team_questio.questio.user.domain.User;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    boolean existsByUsernameAndUserAccountType(String username, AccountType userAccountType);
+    Optional<User> findByUsername(String username);
 
     Optional<User> findByUsernameAndUserAccountType(String username, AccountType userAccountType);
 }

--- a/src/test/java/team_questio/questio/security/application/PrincipleDetailServiceTest.java
+++ b/src/test/java/team_questio/questio/security/application/PrincipleDetailServiceTest.java
@@ -1,0 +1,74 @@
+package team_questio.questio.security.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import team_questio.questio.common.exception.QuestioException;
+import team_questio.questio.common.exception.code.AuthError;
+import team_questio.questio.user.domain.AccountType;
+import team_questio.questio.user.domain.User;
+import team_questio.questio.user.persistence.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class PrincipleDetailServiceTest {
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private OAuth2UserRequest oAuth2UserRequest;
+
+    @Mock
+    private OAuth2User oAuth2User;
+
+    @Mock
+    private ClientRegistration clientRegistration;
+
+    @Mock
+    private DefaultOAuth2UserService defaultOAuth2UserService;
+
+    @InjectMocks
+    private PrincipleDetailService principleDetailService;
+
+    @Test
+    @DisplayName("[Oauth2 회원가입 테스트] 중복된 이메일")
+    void registerUserWithDuplicatedEmailTest() {
+        final String oauthServer = "google";
+        final String emailKey = "email";
+
+        final String email = "test@test.com";
+        final String password = "test";
+
+        final User user = User.of(email, password);
+
+        // DefaultOAuth2UserService.loadUser()에서 호출되는 메서드
+        when(oAuth2UserRequest.getClientRegistration())
+                .thenReturn(clientRegistration);
+        when(oAuth2UserRequest.getClientRegistration().getRegistrationId())
+                .thenReturn(oauthServer);
+        when(defaultOAuth2UserService.loadUser(oAuth2UserRequest))
+                .thenReturn(oAuth2User);
+
+        when(oAuth2User.getAttributes())
+                .thenReturn(Map.of(emailKey, email));
+        when(userRepository.existsByUsernameAndUserAccountType(email, AccountType.GOOGLE))
+                .thenReturn(false);
+        when(userRepository.findByUsername(email))
+                .thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> principleDetailService.loadUser(oAuth2UserRequest))
+                .isInstanceOf(QuestioException.class)
+                .hasMessage(AuthError.EMAIL_ALREADY_EXISTS_NORMAL.message());
+    }
+}

--- a/src/test/java/team_questio/questio/user/application/UserServiceTest.java
+++ b/src/test/java/team_questio/questio/user/application/UserServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,6 +17,7 @@ import team_questio.questio.common.exception.QuestioException;
 import team_questio.questio.common.exception.code.AuthError;
 import team_questio.questio.infra.RedisUtil;
 import team_questio.questio.user.application.command.SignUpCommand;
+import team_questio.questio.user.domain.User;
 import team_questio.questio.user.persistence.UserRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -36,13 +38,15 @@ class UserServiceTest {
         //given
         final String email = "test@test.com";
         final String password = "test";
+        final User user = User.of(email, password);
         SignUpCommand command = new SignUpCommand(email, password);
-        given(userRepository.existsByUsernameAndUserAccountType(any(), any())).willReturn(true);
+        given(userRepository.findByUsername(any()))
+                .willReturn(Optional.of(user));
 
         //when, then
         assertThatThrownBy(() -> userService.registerUser(command))
                 .isInstanceOf(QuestioException.class)
-                .hasMessage(AuthError.EMAIL_ALREADY_EXISTS.message());
+                .hasMessage(AuthError.EMAIL_ALREADY_EXISTS_NORMAL.message());
     }
 
 

--- a/src/test/java/team_questio/questio/user/application/UserServiceTest.java
+++ b/src/test/java/team_questio/questio/user/application/UserServiceTest.java
@@ -17,6 +17,7 @@ import team_questio.questio.common.exception.QuestioException;
 import team_questio.questio.common.exception.code.AuthError;
 import team_questio.questio.infra.RedisUtil;
 import team_questio.questio.user.application.command.SignUpCommand;
+import team_questio.questio.user.domain.AccountType;
 import team_questio.questio.user.domain.User;
 import team_questio.questio.user.persistence.UserRepository;
 
@@ -32,9 +33,9 @@ class UserServiceTest {
     @InjectMocks
     private UserService userService;
 
-    @DisplayName("[유저 테스트] 중복된 이메일 테스트")
+    @DisplayName("[유저 테스트] 중복된 이메일 테스트 / normal -> normal")
     @Test
-    void duplicatedEmailTest() {
+    void duplicatedEmailInNormalTest() {
         //given
         final String email = "test@test.com";
         final String password = "test";
@@ -47,6 +48,24 @@ class UserServiceTest {
         assertThatThrownBy(() -> userService.registerUser(command))
                 .isInstanceOf(QuestioException.class)
                 .hasMessage(AuthError.EMAIL_ALREADY_EXISTS_NORMAL.message());
+    }
+
+    @DisplayName("[유저 테스트] 중복된 이메일 테스트 / normal -> oauth(google)")
+    @Test
+    void duplicatedEmailInOauthTest() {
+        //given
+        final String email = "test@test.com";
+        final String password = "test";
+        final AccountType accountType = AccountType.GOOGLE;
+        final User user = User.of(email, password, accountType);
+        SignUpCommand command = new SignUpCommand(email, password);
+        given(userRepository.findByUsername(any()))
+                .willReturn(Optional.of(user));
+
+        //when, then
+        assertThatThrownBy(() -> userService.registerUser(command))
+                .isInstanceOf(QuestioException.class)
+                .hasMessage(AuthError.EMAIL_ALREADY_EXIST_GOOGLE.message());
     }
 
 


### PR DESCRIPTION
### ✨ 작업 내용

- oauth2와 일반 회원가입 시 중복 이메일 확인 로직을 수정하였습니다.

---

### ✨ 참고 사항

- 일단 테스트코드를 작성해 확인 해봤는데, 로직이 정확하지 않을 수 있습니다.

---

### ⏰ 현재 버그


---

### ✏ Git Close

close #62 
